### PR TITLE
ci: add issue to project board

### DIFF
--- a/.github/workflows/add_issue_to_project.yml
+++ b/.github/workflows/add_issue_to_project.yml
@@ -1,0 +1,26 @@
+---
+
+name: Add Issues To Project Board
+
+"on":
+  issues:
+    types: [opened]
+
+jobs:
+  add_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue project board
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+          PROJECT_ID: ${{ secrets.SMART_CONTRACTS_PROJECT_ID }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'


### PR DESCRIPTION
  In order to make sure that any issues opened against this repo can be triaged, scheduled and worked upon in the team process this GH action adds all new issues to the team project board.